### PR TITLE
Fix for flat-line of weapon projetiles when it should be random scatter

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -6751,9 +6751,23 @@ AActor *P_SpawnPlayerMissile (AActor *source, double x, double y, double z,
 	if (source->player != NULL && source->player->mo->OverrideAttackPosDir)
 	{
 		pos = source->player->mo->AttackPos;
-		DVector3 dir = source->player->mo->AttackDir(source, an, pitch);
+		DAngle p;
+		p.Degrees = 0;
+		DVector3 dir = source->player->mo->AttackDir(source, angle, p);
 		an = dir.Angle();
-		pitch = dir.Pitch();
+
+		//
+		//  FIX FOR FLAT PROJECTILE SPREAD FROM SHOTGUNS AND OTHER MULTI-PROJECTILE WEAPONS
+		//
+        //Bit of a hack as it makes the pitch a little off, but in order for weapon projectile spread
+        //to work correctly, we can't fix the pitch to that of the controller otherwise random spread
+        //turns into a flat line of projectiles. Using the difference between the previous known angles and
+        //the current angles (which were potenitally modified by A_FireProjectile) gives us the "random"
+        //difference applied to the pitch by the script
+        //
+        //A VR player is unlikely to be whipping their head up and down so fast as to make a meaningful
+        //difference to the pitch between two frames, so this is 'good enough' for now.
+		pitch = dir.Pitch() + (source->PrevAngles.Pitch - source->Angles.Pitch);
 	}
 	AActor *MissileActor = Spawn (source->Level, type, pos, ALLOW_REPLACE);
 	if (pMissileActor) *pMissileActor = MissileActor;

--- a/src/rendering/gl/stereo3d/gl_openvr.cpp
+++ b/src/rendering/gl/stereo3d/gl_openvr.cpp
@@ -1003,10 +1003,8 @@ namespace s3d
 
 		yaw -= actor->Angles.Yaw;
 
-		//ignore specified pitch (would need to compensate for auto aim and no (vanilla) Doom weapon varies this)
-		//pitch -= actor->Angles.Pitch;
-		pitch.Degrees = 0;
-
+		//Don't set pitch to 0 here, we need the pitch element for the random projectile spread
+				
 		pc = pitch.Cos();
 
 		LSVec3 local = { (float)(pc * yaw.Cos()), (float)(pc * yaw.Sin()), (float)(-pitch.Sin()), 0.0f };


### PR DESCRIPTION
Here's the PR.. seems to work fine for me in QuestZDoom, I'll be releasing the version with this change in fairly soon. I had to rework my original attempt slightly as I found an issue which is now fixed.

Let me know how you get on!